### PR TITLE
Limit email length to 320 characters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ var matcher = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,6
  * @return {boolean}
  */
 function isEmail(string) {
+  if (string.length > 320) return false;
   return matcher.test(string);
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,4 +17,19 @@ describe('is-email', function() {
     assert.strictEqual(isEmail('team+45.io'), false);
     assert.strictEqual(isEmail('@segmentio.com'), false);
   });
+
+  it('only accepts 320 characters', function() {
+    // 11 characters
+    var domain = '@segment.io';
+    var local = '';
+    var email = '';
+
+    for (var i = 0; i < 310; i++) {
+      local.concat('a');
+    }
+
+    email = local.concat(domain);
+
+    assert.strictEqual(isEmail(email), false);
+  });
 });


### PR DESCRIPTION
This PR limits `is-email`'s input length to a max of 320 characters to prevent DoS attacks where excessively large strings can lead to RangeErrors.